### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/tests/storage_apc_array_test.php
+++ b/tests/storage_apc_array_test.php
@@ -212,7 +212,7 @@ class ezcCacheStorageFileApcArrayTest extends ezcCacheStorageTest
         $storage->restore( $key );
         $registry = $storage->getRegistry();
 
-        list( $identifier, $dataArr ) = each( $registry );
+        $identifier = key( $registry );
 
         $dataFetched = $storage->fetchData( $identifier, true );
         $this->assertEquals( $data, $dataFetched );

--- a/tests/storage_apc_plain_test.php
+++ b/tests/storage_apc_plain_test.php
@@ -85,7 +85,7 @@ class ezcCacheStorageApcPlainTest extends ezcCacheStorageTest
             $registry = $storage->getRegistry();
 
             $location = $this->getTempDir() . DIRECTORY_SEPARATOR;
-            list( $identifier, $dataObj ) = each( $registry[$location][$id] );
+            $identifier = key( $registry[$location][$id] );
             $registry[$location][$id][$identifier]->time = time() - 100;
             $storage->setRegistry( $registry );
 
@@ -117,7 +117,7 @@ class ezcCacheStorageApcPlainTest extends ezcCacheStorageTest
             $registry = $storage->getRegistry();
 
             $location = $this->getTempDir() . DIRECTORY_SEPARATOR;
-            list( $identifier, $dataObj ) = each( $registry[$location][$id] );
+            $identifier = key( $registry[$location][$id] );
             $registry[$location][$id][$identifier]->time = time() - 100;
             $storage->setRegistry( $registry );
 

--- a/tests/storage_memcache_plain_test.php
+++ b/tests/storage_memcache_plain_test.php
@@ -97,7 +97,7 @@ class ezcCacheStorageMemcachePlainTest extends ezcCacheStorageTest
             $registry = $storage->getRegistry();
 
             $location = $this->getTempDir() . DIRECTORY_SEPARATOR;
-            list( $identifier, $dataObj ) = each( $registry[$location][$id] );
+            $identifier = key( $registry[$location][$id] );
             $registry[$location][$id][$identifier]->time = time() - 100;
             $storage->setRegistry( $registry );
 
@@ -128,7 +128,7 @@ class ezcCacheStorageMemcachePlainTest extends ezcCacheStorageTest
             $registry = $storage->getRegistry();
 
             $location = $this->getTempDir() . DIRECTORY_SEPARATOR;
-            list( $identifier, $dataObj ) = each( $registry[$location][$id] );
+            $identifier = key( $registry[$location][$id] );
             $registry[$location][$id][$identifier]->time = time() - 100;
             $storage->setRegistry( $registry );
 


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.2 | /tests/storage_apc_array_test.php:215                                                              | function         | Function each() is deprecated. 
 7.2 | /tests/storage_apc_plain_test.php:88                                                               | function         | Function each() is deprecated. 
 7.2 | /tests/storage_apc_plain_test.php:120                                                              | function         | Function each() is deprecated. 
 7.2 | /tests/storage_memcache_plain_test.php:100                                                         | function         | Function each() is deprecated. 
 7.2 | /tests/storage_memcache_plain_test.php:131                                                         | function         | Function each() is deprecated. 
```